### PR TITLE
Convert marquee banner to continuous scroll

### DIFF
--- a/client/src/components/layout/layout.tsx
+++ b/client/src/components/layout/layout.tsx
@@ -44,7 +44,12 @@ export function Layout({ children }: LayoutProps) {
             {Array.isArray(quotes) && quotes
               .filter((quote: CarouselQuote) => quote.carousel === 'main')
               .map((quote: CarouselQuote) => (
-                <span key={quote.id} className="mx-8 text-lg drop-shadow-sm">{quote.quote}</span>
+                <span
+                  key={quote.id}
+                  className="text-2xl md:text-3xl font-semibold tracking-wide drop-shadow-[0_3px_6px_rgba(0,0,0,0.35)] text-white"
+                >
+                  {quote.quote}
+                </span>
               ))
             }
           </Marquee>

--- a/client/src/components/ui/marquee.tsx
+++ b/client/src/components/ui/marquee.tsx
@@ -3,6 +3,9 @@ import { cn } from "@/lib/utils";
 
 interface MarqueeProps {
   className?: string;
+  /**
+   * Approximate scroll speed in pixels per second.
+   */
   speed?: number;
   pauseOnHover?: boolean;
   direction?: "left" | "right";
@@ -17,29 +20,41 @@ export function Marquee({
   children,
 }: MarqueeProps) {
   const containerRef = React.useRef<HTMLDivElement>(null);
-  const [activeIndex, setActiveIndex] = React.useState(0);
+  const contentRef = React.useRef<HTMLDivElement>(null);
   const [isPaused, setIsPaused] = React.useState(false);
   const [childrenArray, setChildrenArray] = React.useState<React.ReactNode[]>([]);
+  const [animationDuration, setAnimationDuration] = React.useState<number>(20);
 
   // Convert children to array once when they change
   React.useEffect(() => {
-    // Handle both array and single child case
     const childArray = React.Children.toArray(children);
-    // Simply set the array without trying to compare objects (which can have circular refs)
     setChildrenArray(childArray);
   }, [children]);
 
-  // Set up the interval to change the active quote
+  const calculateDuration = React.useCallback(() => {
+    if (!contentRef.current) return;
+
+    const contentWidth = contentRef.current.scrollWidth;
+    if (contentWidth === 0) return;
+
+    const normalizedSpeed = Math.max(speed, 1);
+    setAnimationDuration(Math.max(contentWidth / normalizedSpeed, 5));
+  }, [speed]);
+
   React.useEffect(() => {
-    if (childrenArray.length <= 1) return;
-    
-    const intervalTime = 5000; // 5 seconds per quote
-    const interval = setInterval(() => {
-      setActiveIndex((prevIndex) => (prevIndex + 1) % childrenArray.length);
-    }, intervalTime);
-    
-    return () => clearInterval(interval);
-  }, [childrenArray.length]); // Only depend on the length, not the entire array
+    if (childrenArray.length === 0) return;
+
+    const frame = requestAnimationFrame(() => {
+      calculateDuration();
+    });
+
+    window.addEventListener("resize", calculateDuration);
+
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener("resize", calculateDuration);
+    };
+  }, [childrenArray, calculateDuration]);
 
   const handleMouseEnter = () => {
     if (pauseOnHover) {
@@ -53,35 +68,41 @@ export function Marquee({
     }
   };
 
-  // If there's only one item or none, just render it directly
-  if (childrenArray.length <= 1) {
-    return (
-      <div 
-        className={cn("flex overflow-hidden", className)}
-        ref={containerRef}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
-      >
-        {children}
-      </div>
-    );
+  if (childrenArray.length === 0) {
+    return null;
   }
 
   return (
-    <div 
-      className={cn("flex overflow-hidden", className)}
+    <div
+      className={cn("relative overflow-hidden", className)}
       ref={containerRef}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >
-      <div className="flex items-center justify-center w-full h-full">
-        <div 
-          className="transition-opacity duration-500"
-          style={{
-            opacity: 1,
-          }}
-        >
-          {childrenArray[activeIndex]}
+      <div
+        className="flex items-center whitespace-nowrap"
+        style={{
+          animationName: "marquee-scroll",
+          animationDuration: `${animationDuration}s`,
+          animationTimingFunction: "linear",
+          animationIterationCount: "infinite",
+          animationPlayState: isPaused ? "paused" : "running",
+          animationDirection: direction === "right" ? "reverse" : "normal",
+        }}
+      >
+        <div className="flex items-center" ref={contentRef}>
+          {childrenArray.map((child, index) => (
+            <div key={`marquee-item-${index}`} className="flex items-center">
+              {child}
+            </div>
+          ))}
+        </div>
+        <div className="flex items-center" aria-hidden="true">
+          {childrenArray.map((child, index) => (
+            <div key={`marquee-item-duplicate-${index}`} className="flex items-center">
+              {child}
+            </div>
+          ))}
         </div>
       </div>
     </div>

--- a/client/src/components/ui/marquee.tsx
+++ b/client/src/components/ui/marquee.tsx
@@ -24,6 +24,7 @@ export function Marquee({
   const [isPaused, setIsPaused] = React.useState(false);
   const [childrenArray, setChildrenArray] = React.useState<React.ReactNode[]>([]);
   const [animationDuration, setAnimationDuration] = React.useState<number>(20);
+  const [contentWidth, setContentWidth] = React.useState<number>(0);
 
   // Convert children to array once when they change
   React.useEffect(() => {
@@ -34,11 +35,12 @@ export function Marquee({
   const calculateDuration = React.useCallback(() => {
     if (!contentRef.current) return;
 
-    const contentWidth = contentRef.current.scrollWidth;
-    if (contentWidth === 0) return;
+    const measuredWidth = contentRef.current.scrollWidth;
+    if (measuredWidth === 0) return;
 
     const normalizedSpeed = Math.max(speed, 1);
-    setAnimationDuration(Math.max(contentWidth / normalizedSpeed, 5));
+    setAnimationDuration(Math.max(measuredWidth / normalizedSpeed, 5));
+    setContentWidth(measuredWidth);
   }, [speed]);
 
   React.useEffect(() => {
@@ -80,24 +82,34 @@ export function Marquee({
       onMouseLeave={handleMouseLeave}
     >
       <div
-        className="flex items-center whitespace-nowrap"
-        style={{
-          animationName: "marquee-scroll",
-          animationDuration: `${animationDuration}s`,
-          animationTimingFunction: "linear",
-          animationIterationCount: "infinite",
-          animationPlayState: isPaused ? "paused" : "running",
-          animationDirection: direction === "right" ? "reverse" : "normal",
-        }}
+        className="flex items-center whitespace-nowrap px-10"
+        style={(() => {
+          const marqueeStyle: React.CSSProperties & {
+            "--marquee-width"?: string;
+          } = {
+            animationName: "marquee-scroll",
+            animationDuration: `${animationDuration}s`,
+            animationTimingFunction: "linear",
+            animationIterationCount: "infinite",
+            animationPlayState: isPaused ? "paused" : "running",
+            animationDirection: direction === "right" ? "reverse" : "normal",
+          };
+
+          if (contentWidth > 0) {
+            marqueeStyle["--marquee-width"] = `${contentWidth}px`;
+          }
+
+          return marqueeStyle;
+        })()}
       >
-        <div className="flex items-center" ref={contentRef}>
+        <div className="flex items-center gap-24" ref={contentRef}>
           {childrenArray.map((child, index) => (
             <div key={`marquee-item-${index}`} className="flex items-center">
               {child}
             </div>
           ))}
         </div>
-        <div className="flex items-center" aria-hidden="true">
+        <div className="flex items-center gap-24" aria-hidden="true">
           {childrenArray.map((child, index) => (
             <div key={`marquee-item-duplicate-${index}`} className="flex items-center">
               {child}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -127,7 +127,7 @@
       transform: translateX(0);
     }
     100% {
-      transform: translateX(-50%);
+      transform: translateX(calc(-1 * var(--marquee-width, 50%)));
     }
   }
   

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -116,10 +116,19 @@
     40% { transform: translateY(-10px); }
     60% { transform: translateY(-5px); }
   }
-  
+
   @keyframes scaleIn {
     0% { transform: scale(0.95); opacity: 0; }
     100% { transform: scale(1); opacity: 1; }
+  }
+
+  @keyframes marquee-scroll {
+    0% {
+      transform: translateX(0);
+    }
+    100% {
+      transform: translateX(-50%);
+    }
   }
   
   /* Custom button styles */


### PR DESCRIPTION
## Summary
- replace the marquee component's timed swapping with a continuously scrolling track that clones its content for a seamless loop
- compute the marquee animation duration from rendered width and pause the scroll when hovered
- add global marquee-scroll keyframes to support the new animation

## Testing
- npm run test *(fails: npm not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dab99ff3808323b016536a4ba004cc