### PR TITLE
Improve Airtable team syncing

### DIFF
--- a/client/src/components/layout/layout.tsx
+++ b/client/src/components/layout/layout.tsx
@@ -44,7 +44,12 @@ export function Layout({ children }: LayoutProps) {
             {Array.isArray(quotes) && quotes
               .filter((quote: CarouselQuote) => quote.carousel === 'main')
               .map((quote: CarouselQuote) => (
-                <span key={quote.id} className="mx-8 text-lg drop-shadow-sm">{quote.quote}</span>
+                <span
+                  key={quote.id}
+                  className="text-2xl md:text-3xl font-semibold tracking-wide drop-shadow-[0_3px_6px_rgba(0,0,0,0.35)] text-white"
+                >
+                  {quote.quote}
+                </span>
               ))
             }
           </Marquee>

--- a/client/src/components/ui/marquee.tsx
+++ b/client/src/components/ui/marquee.tsx
@@ -3,6 +3,9 @@ import { cn } from "@/lib/utils";
 
 interface MarqueeProps {
   className?: string;
+  /**
+   * Approximate scroll speed in pixels per second.
+   */
   speed?: number;
   pauseOnHover?: boolean;
   direction?: "left" | "right";
@@ -17,29 +20,41 @@ export function Marquee({
   children,
 }: MarqueeProps) {
   const containerRef = React.useRef<HTMLDivElement>(null);
-  const [activeIndex, setActiveIndex] = React.useState(0);
+  const contentRef = React.useRef<HTMLDivElement>(null);
   const [isPaused, setIsPaused] = React.useState(false);
   const [childrenArray, setChildrenArray] = React.useState<React.ReactNode[]>([]);
+  const [animationDuration, setAnimationDuration] = React.useState<number>(20);
 
   // Convert children to array once when they change
   React.useEffect(() => {
-    // Handle both array and single child case
     const childArray = React.Children.toArray(children);
-    // Simply set the array without trying to compare objects (which can have circular refs)
     setChildrenArray(childArray);
   }, [children]);
 
-  // Set up the interval to change the active quote
+  const calculateDuration = React.useCallback(() => {
+    if (!contentRef.current) return;
+
+    const contentWidth = contentRef.current.scrollWidth;
+    if (contentWidth === 0) return;
+
+    const normalizedSpeed = Math.max(speed, 1);
+    setAnimationDuration(Math.max(contentWidth / normalizedSpeed, 5));
+  }, [speed]);
+
   React.useEffect(() => {
-    if (childrenArray.length <= 1) return;
-    
-    const intervalTime = 5000; // 5 seconds per quote
-    const interval = setInterval(() => {
-      setActiveIndex((prevIndex) => (prevIndex + 1) % childrenArray.length);
-    }, intervalTime);
-    
-    return () => clearInterval(interval);
-  }, [childrenArray.length]); // Only depend on the length, not the entire array
+    if (childrenArray.length === 0) return;
+
+    const frame = requestAnimationFrame(() => {
+      calculateDuration();
+    });
+
+    window.addEventListener("resize", calculateDuration);
+
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener("resize", calculateDuration);
+    };
+  }, [childrenArray, calculateDuration]);
 
   const handleMouseEnter = () => {
     if (pauseOnHover) {
@@ -53,35 +68,41 @@ export function Marquee({
     }
   };
 
-  // If there's only one item or none, just render it directly
-  if (childrenArray.length <= 1) {
-    return (
-      <div 
-        className={cn("flex overflow-hidden", className)}
-        ref={containerRef}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
-      >
-        {children}
-      </div>
-    );
+  if (childrenArray.length === 0) {
+    return null;
   }
 
   return (
-    <div 
-      className={cn("flex overflow-hidden", className)}
+    <div
+      className={cn("relative overflow-hidden", className)}
       ref={containerRef}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >
-      <div className="flex items-center justify-center w-full h-full">
-        <div 
-          className="transition-opacity duration-500"
-          style={{
-            opacity: 1,
-          }}
-        >
-          {childrenArray[activeIndex]}
+      <div
+        className="flex items-center whitespace-nowrap"
+        style={{
+          animationName: "marquee-scroll",
+          animationDuration: `${animationDuration}s`,
+          animationTimingFunction: "linear",
+          animationIterationCount: "infinite",
+          animationPlayState: isPaused ? "paused" : "running",
+          animationDirection: direction === "right" ? "reverse" : "normal",
+        }}
+      >
+        <div className="flex items-center" ref={contentRef}>
+          {childrenArray.map((child, index) => (
+            <div key={`marquee-item-${index}`} className="flex items-center">
+              {child}
+            </div>
+          ))}
+        </div>
+        <div className="flex items-center" aria-hidden="true">
+          {childrenArray.map((child, index) => (
+            <div key={`marquee-item-duplicate-${index}`} className="flex items-center">
+              {child}
+            </div>
+          ))}
         </div>
       </div>
     </div>

--- a/client/src/components/ui/marquee.tsx
+++ b/client/src/components/ui/marquee.tsx
@@ -24,6 +24,7 @@ export function Marquee({
   const [isPaused, setIsPaused] = React.useState(false);
   const [childrenArray, setChildrenArray] = React.useState<React.ReactNode[]>([]);
   const [animationDuration, setAnimationDuration] = React.useState<number>(20);
+  const [contentWidth, setContentWidth] = React.useState<number>(0);
 
   // Convert children to array once when they change
   React.useEffect(() => {
@@ -34,11 +35,12 @@ export function Marquee({
   const calculateDuration = React.useCallback(() => {
     if (!contentRef.current) return;
 
-    const contentWidth = contentRef.current.scrollWidth;
-    if (contentWidth === 0) return;
+    const measuredWidth = contentRef.current.scrollWidth;
+    if (measuredWidth === 0) return;
 
     const normalizedSpeed = Math.max(speed, 1);
-    setAnimationDuration(Math.max(contentWidth / normalizedSpeed, 5));
+    setAnimationDuration(Math.max(measuredWidth / normalizedSpeed, 5));
+    setContentWidth(measuredWidth);
   }, [speed]);
 
   React.useEffect(() => {
@@ -80,24 +82,34 @@ export function Marquee({
       onMouseLeave={handleMouseLeave}
     >
       <div
-        className="flex items-center whitespace-nowrap"
-        style={{
-          animationName: "marquee-scroll",
-          animationDuration: `${animationDuration}s`,
-          animationTimingFunction: "linear",
-          animationIterationCount: "infinite",
-          animationPlayState: isPaused ? "paused" : "running",
-          animationDirection: direction === "right" ? "reverse" : "normal",
-        }}
+        className="flex items-center whitespace-nowrap px-10"
+        style={(() => {
+          const marqueeStyle: React.CSSProperties & {
+            "--marquee-width"?: string;
+          } = {
+            animationName: "marquee-scroll",
+            animationDuration: `${animationDuration}s`,
+            animationTimingFunction: "linear",
+            animationIterationCount: "infinite",
+            animationPlayState: isPaused ? "paused" : "running",
+            animationDirection: direction === "right" ? "reverse" : "normal",
+          };
+
+          if (contentWidth > 0) {
+            marqueeStyle["--marquee-width"] = `${contentWidth}px`;
+          }
+
+          return marqueeStyle;
+        })()}
       >
-        <div className="flex items-center" ref={contentRef}>
+        <div className="flex items-center gap-24" ref={contentRef}>
           {childrenArray.map((child, index) => (
             <div key={`marquee-item-${index}`} className="flex items-center">
               {child}
             </div>
           ))}
         </div>
-        <div className="flex items-center" aria-hidden="true">
+        <div className="flex items-center gap-24" aria-hidden="true">
           {childrenArray.map((child, index) => (
             <div key={`marquee-item-duplicate-${index}`} className="flex items-center">
               {child}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -127,7 +127,7 @@
       transform: translateX(0);
     }
     100% {
-      transform: translateX(-50%);
+      transform: translateX(calc(-1 * var(--marquee-width, 50%)));
     }
   }
   

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -116,10 +116,19 @@
     40% { transform: translateY(-10px); }
     60% { transform: translateY(-5px); }
   }
-  
+
   @keyframes scaleIn {
     0% { transform: scale(0.95); opacity: 0; }
     100% { transform: scale(1); opacity: 1; }
+  }
+
+  @keyframes marquee-scroll {
+    0% {
+      transform: translateX(0);
+    }
+    100% {
+      transform: translateX(-50%);
+    }
   }
   
   /* Custom button styles */

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -28,6 +28,16 @@ export class AirtableStorage implements IStorage {
   private base: Airtable.Base;
   private quotes: CarouselQuote[] = [];
   private quoteLastFetched: Date | null = null;
+  private readonly teamTableCandidates = [
+    'Teams',
+    'Team',
+    'Team Members',
+    'Members',
+    'Club Members',
+    'Member Directory',
+    'Roster',
+    'Piscoc Members'
+  ];
 
   constructor() {
     Airtable.configure({
@@ -190,57 +200,72 @@ export class AirtableStorage implements IStorage {
   }
 
   async getTeamMembers(): Promise<Team[]> {
-    try {
-      // Check if the table exists first by trying to access it
-      const query = this.base('Teams').select({
-        sort: [{ field: 'Name', direction: 'asc' }]
-      });
+    const attemptedTables: string[] = [];
 
-      const records = await query.all();
-      return records.map(this.mapAirtableRecordToTeamMember);
-    } catch (error: any) {
-      // Log detailed error information
-      console.error('Error fetching team members from Airtable:', error);
+    for (const tableName of this.getTeamTableCandidates()) {
+      try {
+        attemptedTables.push(tableName);
 
-      // If we have authorization issues, log a more specific message
-      if (error.statusCode === 403) {
-        console.warn('Authorization issue detected with Airtable Teams table. Check API key permissions.');
-        console.log('Falling back to sample team members data');
-        // Return sample team members when there's an authorization error
-        return this.getSampleTeamMembers();
-      } else if (error.statusCode === 404) {
-        console.warn('Teams table not found in Airtable base. Check table name and base configuration.');
-        console.log('Falling back to sample team members data');
-        // Return sample team members when the table doesn't exist
-        return this.getSampleTeamMembers();
+        const query = this.base(tableName).select();
+        const records = await query.all();
+
+        if (!records || records.length === 0) {
+          console.warn(`Airtable table "${tableName}" returned no team member records. Trying next candidate if available.`);
+          continue;
+        }
+
+        const team = records
+          .map(record => this.mapAirtableRecordToTeamMember(record))
+          .sort((a, b) => a.name.localeCompare(b.name));
+
+        console.log(`Fetched ${team.length} team members from Airtable table "${tableName}".`);
+        return team;
+      } catch (error: any) {
+        if (this.isPermissionError(error)) {
+          console.warn(`Authorization issue detected with Airtable table "${tableName}". Falling back to sample data.`);
+          return this.getSampleTeamMembers();
+        }
+
+        if (this.isMissingTableError(error)) {
+          console.warn(`Airtable table "${tableName}" not found. Trying next candidate if available.`);
+          continue;
+        }
+
+        console.error(`Error fetching team members from Airtable table "${tableName}":`, error);
       }
-
-      // Return empty array for other errors
-      return [];
     }
+
+    if (attemptedTables.length > 0) {
+      console.error(`Unable to fetch team members from Airtable. Tables attempted: ${attemptedTables.join(', ')}.`);
+    }
+
+    return [];
   }
 
   async getTeamMemberById(id: string): Promise<Team | undefined> {
-    try {
-      const record = await this.base('Teams').find(id);
-      return this.mapAirtableRecordToTeamMember(record);
-    } catch (error: any) {
-      console.error(`Error fetching team member ${id} from Airtable:`, error);
+    for (const tableName of this.getTeamTableCandidates()) {
+      try {
+        const record = await this.base(tableName).find(id);
+        if (record) {
+          return this.mapAirtableRecordToTeamMember(record);
+        }
+      } catch (error: any) {
+        if (this.isPermissionError(error)) {
+          console.warn(`Authorization issue detected with Airtable table "${tableName}" for ID ${id}. Falling back to sample data.`);
+          const sampleTeamMembers = this.getSampleTeamMembers();
+          return sampleTeamMembers.find(member => member.id === id) || sampleTeamMembers[0];
+        }
 
-      // If we have authorization issues, log a more specific message
-      if (error.statusCode === 403) {
-        console.warn(`Authorization issue detected with Airtable Teams table for ID ${id}. Check API key permissions.`);
-        console.log('Falling back to sample team members data');
-        // Return a sample team member when there's an authorization error
-        const sampleTeamMembers = this.getSampleTeamMembers();
-        // Try to find a sample member with the matching ID, or return the first one if not found
-        return sampleTeamMembers.find(member => member.id === id) || sampleTeamMembers[0];
-      } else if (error.statusCode === 404) {
-        console.warn(`Team member with ID ${id} not found in Airtable or Teams table does not exist.`);
+        if (this.isMissingTableError(error) || this.isRecordNotFoundError(error)) {
+          console.warn(`Team member with ID ${id} not found in Airtable table "${tableName}". Trying next candidate.`);
+          continue;
+        }
+
+        console.error(`Error fetching team member ${id} from Airtable table "${tableName}":`, error);
       }
-
-      return undefined;
     }
+
+    return undefined;
   }
 
   async getQuotes(): Promise<CarouselQuote[]> {
@@ -432,55 +457,179 @@ export class AirtableStorage implements IStorage {
   }
 
   private mapAirtableRecordToTeamMember(record: Airtable.Record<any>): Team {
+    const imageUrl = this.extractTeamImageUrl(record);
 
+    const name = this.extractStringField(record, [
+      'Name',
+      'name',
+      'Full Name',
+      'Full name',
+      'Display Name',
+      'Preferred Name',
+      'Member Name'
+    ]) || record.id;
 
-    // Use MainImageLink as the primary source for image URLs
-    let imageUrl = '';
+    const role = this.extractStringField(record, [
+      'Role',
+      'role',
+      'Position',
+      'Title',
+      'Positions',
+      'Club Role',
+      'Team Role'
+    ]);
 
-    // Prioritize MainImageLink field
-    const mainImageLink = record.get('MainImageLink') as string;
+    const bio = this.extractStringField(record, [
+      'Bio',
+      'bio',
+      'Biography',
+      'About',
+      'About Me',
+      'Description'
+    ]);
 
-    if (mainImageLink) {
-      // Create a proxy URL using the MainImageLink URL
-      imageUrl = ImageService.getProxyUrl(mainImageLink);
-    }
-    // Fallback to other URL fields if MainImageLink is not available
-    else {
-      const directUrl = record.get('imageUrl') as string ||
-        record.get('Image URL') as string ||
-        record.get('Image') as string ||
-        record.get('image') as string ||
-        '';
+    const authorSub = this.normalizeLinkedRecordField(
+      record.get('AuthorSub') || record.get('authorSub') || record.get('Author Sub')
+    );
 
-      if (directUrl) {
-        // Proxy the direct URL as well
-        imageUrl = ImageService.getProxyUrl(directUrl);
-      }
-    }
-
-
-    // Handle role field which can be an array or string
-    const roleField = record.get('role') || record.get('Role');
-    const role = Array.isArray(roleField) ? roleField.join(', ') : (roleField as string || '');
-
-    // Handle authorSub and photoSub fields - these are arrays of article IDs
-    const authorSubField = record.get('AuthorSub') || record.get('authorSub') || record.get('Author Sub');
-    const authorSub = Array.isArray(authorSubField) ? authorSubField : (authorSubField ? [authorSubField] : undefined);
-
-    const photoSubField = record.get('PhotoSub') || record.get('photoSub') || record.get('Photo Sub');
-    const photoSub = Array.isArray(photoSubField) ? photoSubField : (photoSubField ? [photoSubField] : undefined);
+    const photoSub = this.normalizeLinkedRecordField(
+      record.get('PhotoSub') || record.get('photoSub') || record.get('Photo Sub')
+    );
 
     return {
       id: record.id,
-      name: record.get('name') as string || record.get('Name') as string || '',
-      role: role,
-      bio: record.get('bio') as string || record.get('Bio') as string || '',
-      imageUrl: imageUrl,
-      imageType: 'url', // Always use URL type since we're proxying
-      imagePath: null, // No need for local path when using proxy
-      authorSub: authorSub,
-      photoSub: photoSub
+      name,
+      role,
+      bio,
+      imageUrl,
+      imageType: 'url',
+      imagePath: null,
+      authorSub,
+      photoSub
     };
+  }
+
+  private getTeamTableCandidates(): string[] {
+    return Array.from(new Set(this.teamTableCandidates));
+  }
+
+  private isPermissionError(error: any): boolean {
+    return error?.statusCode === 403;
+  }
+
+  private isMissingTableError(error: any): boolean {
+    if (!error) return false;
+    if (error.statusCode === 404) {
+      const message = String(error.message || '').toLowerCase();
+      return message.includes('could not find table') || message.includes('table') || message === '';
+    }
+    return false;
+  }
+
+  private isRecordNotFoundError(error: any): boolean {
+    return error?.statusCode === 404 || error?.error === 'NOT_FOUND';
+  }
+
+  private extractStringField(record: Airtable.Record<any>, fieldNames: string[]): string {
+    for (const fieldName of fieldNames) {
+      const value = record.get(fieldName);
+      if (value === undefined || value === null) {
+        continue;
+      }
+
+      if (Array.isArray(value)) {
+        const strings = value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
+        if (strings.length > 0) {
+          return strings.join(', ');
+        }
+      } else if (typeof value === 'string') {
+        if (value.trim().length > 0) {
+          return value;
+        }
+      } else if (typeof value === 'number') {
+        return value.toString();
+      }
+    }
+
+    return '';
+  }
+
+  private normalizeLinkedRecordField(value: any): string[] | undefined {
+    if (!value) {
+      return undefined;
+    }
+
+    if (Array.isArray(value)) {
+      const items = value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
+      return items.length > 0 ? items : undefined;
+    }
+
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return [value];
+    }
+
+    return undefined;
+  }
+
+  private extractTeamImageUrl(record: Airtable.Record<any>): string {
+    const imageFieldCandidates = [
+      'MainImageLink',
+      'Main Image Link',
+      'MainImage',
+      'Image',
+      'image',
+      'Image URL',
+      'imageUrl',
+      'Photo',
+      'Headshot',
+      'Profile Photo',
+      'Profile Picture',
+      'Picture',
+      'Portrait',
+      'Avatar'
+    ];
+
+    for (const fieldName of imageFieldCandidates) {
+      const value = record.get(fieldName);
+      const resolvedUrl = this.resolveImageField(value);
+      if (resolvedUrl) {
+        return ImageService.getProxyUrl(resolvedUrl);
+      }
+    }
+
+    return '';
+  }
+
+  private resolveImageField(fieldValue: any): string | null {
+    if (!fieldValue) {
+      return null;
+    }
+
+    if (typeof fieldValue === 'string') {
+      return fieldValue;
+    }
+
+    if (Array.isArray(fieldValue)) {
+      for (const entry of fieldValue) {
+        if (!entry) {
+          continue;
+        }
+
+        if (typeof entry === 'string' && entry.trim().length > 0) {
+          return entry;
+        }
+
+        if (typeof entry === 'object' && 'url' in entry && typeof entry.url === 'string' && entry.url.trim().length > 0) {
+          return entry.url;
+        }
+      }
+    }
+
+    if (typeof fieldValue === 'object' && 'url' in fieldValue && typeof fieldValue.url === 'string' && fieldValue.url.trim().length > 0) {
+      return fieldValue.url;
+    }
+
+    return null;
   }
 }
 


### PR DESCRIPTION
## Summary
- add fallback logic to load team members from multiple Airtable tables so the Piscoc roster stays in sync
- normalize field extraction for team records, including attachment-based headshots and alternative name/role fields

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1b0098f0c8323ad788038666a6a07